### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 # This workflow runs standard unit tests to ensure basic integrity and avoid
 # regressions on pull-requests (and pushes)


### PR DESCRIPTION
Potential fix for [https://github.com/node-oauth/express-oauth-server/security/code-scanning/28](https://github.com/node-oauth/express-oauth-server/security/code-scanning/28)

To fix the problem, explicitly set least-privilege `GITHUB_TOKEN` permissions for this workflow. Since this workflow only checks out code, installs dependencies, runs tests, lints, builds docs, and checks coverage, it only needs read access to repository contents. No steps require write access to the repo, issues, pull requests, or other scopes.

The best fix without changing existing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`). This will apply to all jobs in the workflow, including `unittest`, and limit the token appropriately. Specifically, in `.github/workflows/tests.yml`, after the `name: Tests` line (line 1), insert:

```yaml
permissions:
  contents: read
```

This change requires no additional imports, methods, or definitions, and does not alter any job logic; it only changes the default token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
