### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/node-oauth/express-oauth-server.git"
+    "url": "git+https://github.com/node-oauth/express-oauth-server.git"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
## Summary
- update the package repository metadata to use the public HTTPS GitHub URL
- keep the change limited to package metadata

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/node-oauth/express-oauth-server.git HEAD
- npm pack --dry-run --ignore-scripts --json passed
